### PR TITLE
bump tag exists action version

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check if version exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@v1.1.0
         id: tagcheck
         with:
           tag: ${{ env.VDA_VER }}


### PR DESCRIPTION
This PR bumps the tag-exists-action version to v1.1.0 which should get rid of some of [these warnings](https://github.com/Ichunjo/vardautomation/actions/runs/3331521374):
![image](https://user-images.githubusercontent.com/4502154/198848472-5406653e-75fb-4d9c-8e7b-3fd9e0a154d3.png)
